### PR TITLE
translate structures to solids in non-preview mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-lib/ldraw/
+lib/
 __pycache__/
 .vscode/
 test_anim/


### PR DESCRIPTION
We translate the LDraw structures to solids instead of fancy looking
colored faces in non-preview mode by default. This allows OpenSCAD
to generate valid STL files to the degree the solids are well-formed
solids in the LDraw library and fix the rest with an external tool.
    
For rendering PNG images this has no impact since they will be
rendered in preview mode anyway.
    
Additionally this implements a few convenience functions like
calculation of the bounding box, the center of the models and their
size.
