### PR TITLE
allow compiling the whole LDraw library to an OpenSCAD library

### DIFF
--- a/demo.scad
+++ b/demo.scad
@@ -1,0 +1,6 @@
+step = 0;
+
+use <openscad/lib.scad>
+use <openscad/models/car.scad>
+
+makepoly(ldraw_lib__car(), step=step);

--- a/ldraw_to_scad.py
+++ b/ldraw_to_scad.py
@@ -1,266 +1,303 @@
 #!/usr/bin/env python3
 
+""" Translate LDraw library or file to OpenSCAD library or file. """
+
 import os
 import argparse
-import queue
-
-class Module():
-    def __init__(self, filename):
-        self.filename = filename
-        self.lines = []
-        self.module_name = None
-        # Name of module only
-        self.dependancies = set()
-
-    @staticmethod
-    def make_module_name(filename):
-        module_name = filename.split('.', 1)[0]
-        module_name = module_name.replace('\\', '__').replace('-', '_')
-        return 'n__' + module_name
-
-    def get_module_name(self):
-        if not self.module_name:
-            self.module_name = self.make_module_name(self.filename)
-        return self.module_name
-
-    def add_lines(self, lines):
-        self.lines.extend(lines)
-
-    def get_lines(self):
-        return self.get_module_code()
-
-    def get_module_code(self):
-        func_lines = ['  {}'.format(line) 
-            for line in self.lines]
-
-        return [
-            "function {}() = [".format(self.get_module_name())
-        ] + func_lines + [
-            "];"
-        ]
-
-
-def colorfile(library_root):
-    """ Translate color specifications. """
-    coltxt = ('function ldraw_color(id, alt=false) = alt ?'
-              ' ldraw_color_LDCfgalt(id) :'
-              ' ldraw_color_LDConfig(id);\n')
-    for colfile in ['LDConfig', 'LDCfgalt']:
-        with open(os.path.join(library_root, colfile+'.ldr'),
-                  encoding="utf-8", errors='replace') as filedata:
-            lines = filedata.readlines()
-        colors = [f'function ldraw_color_{colfile}(id) = (']
-        for line in lines:
-            params = line.split()
-            if len(params) >= 2 and params[0] == '0' and \
-               params[1] == '!COLOUR':
-                data = {}
-                if len(params) == 2:
-                    print('!COLOUR line with no data!')
-                data['name'] = params[2]
-                skip = False
-                for pos, opt in enumerate(params[3:]):
-                    if skip:
-                        skip = False
-                        continue
-                    if opt in ['CODE', 'VALUE', 'ALPHA', 'LUMINANCE', 'EDGE',
-                               'SIZE', 'MINSIZE', 'MAXSIZE', 'FRACTION',
-                               'VFRACTION', 'MATERIAL']:
-                        data[opt] = params[pos+4]
-                        skip = True
-                    elif opt in ['METAL', 'RUBBER', 'PEARLESCENT', 'CHROME']:
-                        data[opt] = True
-                    else:
-                        print(f'Unknown !COLOUR option {opt}!')
-                colors.append(
-                    f'(id=={data["CODE"]}) ? ["{data["VALUE"]}'
-                    f'{(int(data["ALPHA"]) if "ALPHA" in data else 255):02X}'
-                    f'","{data["EDGE"]}"] : (')
-        colors.append('"UNKNOWN"'+')'*len(colors)+';')
-        coltxt += '\n'.join(colors) + '\n'
-    return coltxt
 
 
 class LDrawConverter:
-    def __init__(self):
-        # Ref name: module class
-        self.modules = {}
-        # Ref - queue of names only
-        self.modules_queue = queue.Queue()
-        # Path search
-        self.index = {}
-        self.current_module = None
+    """ Convert LDraw files to OpenSCAD """
 
-    def process_lines(self, module, lines):
-        self.current_module = module
-        result = []
-        first_line = True
-        for line in lines:
-            if first_line and line.startswith("0 FILE"):
-                if module.filename == "__main__":
-                    continue
-            first_line = False
-            converted = self.convert_line(line)
-            self.current_module.add_lines(converted)
+    def __init__(self, line=0.2, commented=True):
+        self.library_root = os.path.join('lib', 'ldraw')
+        self.index = self.index_library()
+        self.queue = ({}, set())
+        self.filedep = None
+        self.settings = {
+            'selfcontained': None,
+            'line': line,
+            'commented': commented}
+        self.mpd_main = None
 
-    def get_module_lines(self, module_name):
-        real_filename = self.find_part(module_name)
-        with open(real_filename) as fd:
-            lines = fd.readlines()
-        return lines
-
-    def process_main(self, input_lines, line_width=0.2):
-        main_module = Module('__main__')
-        self.modules[main_module.get_module_name()] = main_module
-        self.modules_queue.put(main_module)
-        self.process_lines(main_module, input_lines)
-        completed = []
-        while not self.modules_queue.empty():
-            # Get the next queued module
-            current_module = self.modules_queue.get()
-            # Has it been done?
-            if current_module.get_module_name() in completed:
-                continue
-            # Have we loaded it?
-            if not current_module.lines:
-                print("Main module lines is", len(main_module.lines))
-                lines = self.get_module_lines(current_module.filename)
-                self.process_lines(current_module, lines)
-            # Check - have we covered it dependancies
-            new_dependancy = False
-            for dep in current_module.dependancies:
-                if dep not in completed:
-                    self.modules_queue.put(self.modules[dep])
-                    self.modules_queue.put(current_module)
-                    new_dependancy = True
-            if not new_dependancy:
-                # Ok - ready to go - add to completed
-                completed.append(current_module.get_module_name())
-        # Now we can create output lines - starting at the top
-        # of completed modules.
-        with open('lib.scad') as fd:
-            output_lines = [ colorfile(os.path.join('lib', 'ldraw')) +
-                             ''.join(fd.readlines()) +
-                             '\nmakepoly(n____main__(), line={});'.format(line_width) ]
-        [output_lines.extend(self.modules[module_name].get_lines())
-            for module_name in completed]
-        return output_lines
-
-    def handle_type_0_line(self, rest):
-        # Ignore NOFILE for now
-        if rest.startswith("NOFILE"):
-            return False, ""
-        # Handle the file case
-        if rest.startswith("FILE"):
-            _, filename = rest.split()
-            self.current_module = Module(filename=filename)
-            module_name = Module.make_module_name(filename)
-            self.modules[module_name] = self.current_module
-            return True, ''
-        if rest.startswith("BFC"):
-            params = rest.split()
-            return False, ' '.join(['[0,"BFC","{}"],'.format(param) for param in params[1:]])
-        if rest.startswith('STEP'):
-            return False, '[0,"STEP"],'
-
-        return False, "// {}".format(rest)
-
-    def handle_type_1_line(self, colour_index, x, y, z, a, b, c, d, e, f, g, h, i, filename):
-        module_name = Module.make_module_name(filename)
-        # Is this a new module?
-        if module_name not in self.modules:
-            # Create it
-            self.modules[module_name] = Module(filename)
-        # Add to deps
-        self.current_module.dependancies.add(module_name)
-
-        return [
-                "[1, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {},"
-                " {}, {}()],".format(
-                    colour_index, x, y, z, a, b, c, d, e, f, g, h, i,
-                    module_name)
-        ]
-
-    def convert_line(self, part_line, indent=0):
-        # Preserve blank lines
-        part_line = part_line.strip()
-        if part_line == '':
-            return [part_line]
-        try:
-            command, rest = part_line.split(maxsplit=1)
-        except ValueError:
-            command = part_line
-            rest = ''
-        result = []
-        if command == "0":
-            is_new_module, data = self.handle_type_0_line(rest)
-            if not is_new_module:
-                result.append(data)
-        elif command == "1":
-            try:
-                result.extend(self.handle_type_1_line(*rest.split()))
-            except TypeError:
-                raise TypeError("Insufficient arguments in type 1 line", rest)
-        elif command in ["2", "3", "4", "5"]:
-            result.append(("[{}, {}],").format(
-                command, ', '.join(rest.split()[:{"2" : 7, "3": 10, "4": 13, "5": 13}[command]])))
-        if indent:
-            indent_str = ''.join(' ' * indent)
-            result = ['{i}{l}'.format(i=indent_str, l=line) for line in result]
-        return result
+    def colorfile(self):
+        """ Translate color specifications. """
+        coltxt = ('function ldraw_color(id, alt=false) = alt ?'
+                  ' ldraw_color_LDCfgalt(id) :'
+                  ' ldraw_color_LDConfig(id);\n')
+        for colfile in ['LDConfig', 'LDCfgalt']:
+            with open(os.path.join(self.library_root, colfile+'.ldr'),
+                      encoding="utf-8", errors='replace') as filedata:
+                lines = filedata.readlines()
+            colors = [f'function ldraw_color_{colfile}(id) = (']
+            for line in lines:
+                params = line.split()
+                if len(params) >= 2 and params[0] == '0' and \
+                   params[1] == '!COLOUR':
+                    data = {}
+                    if len(params) == 2:
+                        print('!COLOUR line with no data!')
+                    data['name'] = params[2]
+                    skip = False
+                    for pos, opt in enumerate(params[3:]):
+                        if skip:
+                            skip = False
+                            continue
+                        if opt in ['CODE', 'VALUE', 'ALPHA', 'LUMINANCE',
+                                   'EDGE', 'SIZE', 'MINSIZE', 'MAXSIZE',
+                                   'FRACTION', 'VFRACTION', 'MATERIAL']:
+                            data[opt] = params[pos+4]
+                            skip = True
+                        elif opt in ['METAL', 'RUBBER', 'PEARLESCENT',
+                                     'CHROME']:
+                            data[opt] = True
+                        else:
+                            print(f'Unknown !COLOUR option {opt}!')
+                    alpha = int(data["ALPHA"]) if "ALPHA" in data else 255
+                    colors.append(
+                        f'(id=={data["CODE"]}) ? ["{data["VALUE"]}{alpha:02X}'
+                        f'","{data["EDGE"]}"] : (')
+            colors.append('"UNKNOWN"'+')'*len(colors)+';')
+            coltxt += '\n'.join(colors) + '\n'
+        return coltxt
 
     def index_library(self):
-        """Create an index of all LDRAW library items.
-        The index is a dictionary:
-        {"part_prefix\\part_name": "real_file_name.dat"},
-        eg:
-        {"1.dat": }
-        """
-        self.index = {}
-        paths = ['.']
-        for item in os.listdir('.'):
-            if item.endswith('.dat'):
-                self.index[item] = item
-
-        library_root = os.path.join('lib', 'ldraw')
-        for sub_path in ['parts', 'p']:
-            whole_path = os.path.join(library_root, sub_path) 
+        """ Index the whole library. """
+        index = {}
+        for sub_path in ['models', 'parts', 'p']:
+            whole_path = os.path.join(self.library_root, sub_path)
             for item in os.listdir(whole_path):
                 if item.endswith('.dat'):
-                    self.index[item] = os.path.join(whole_path, item)
+                    index[item] = (sub_path, os.path.splitext(item)[0])
         special_subs = {
-            's': os.path.join(library_root, 'parts', 's'),
-            '48' : os.path.join(library_root, 'p', '48'),
-            '8' : os.path.join(library_root, 'p', '8')
+            's': os.path.join('parts', 's'),
+            '48': os.path.join('p', '48'),
+            '8': os.path.join('p', '8')
         }
         for prefix, s_path in special_subs.items():
-            for item in os.listdir(s_path):
+            for item in os.listdir(os.path.join(self.library_root, s_path)):
                 if item.endswith('.dat'):
-                    self.index[prefix + '\\'+item] = os.path.join(s_path, item)
+                    index[prefix + '\\'+item] = (s_path,
+                                                 os.path.splitext(item)[0])
+        return index
 
     def find_part(self, part_name):
-        if not self.index:
-            self.index_library()
+        """ Find a part in the library. """
         try:
             filename = self.index[part_name]
         except KeyError:
             filename = self.index[part_name.lower()]
         return filename
 
+    def implement_function(self, function):
+        """ register implementation of a function """
+        first = not self.filedep[1]
+        self.filedep[1].add(function)
+        self.filedep[0].discard(function)
+        return first
+
+    def get_dummy(self):
+        """ get a name for a dummy function """
+        cnt = 1
+        while f'DUMMY_{cnt}' in self.filedep[1]:
+            cnt += 1
+        name = f'DUMMY_{cnt}'
+        self.implement_function(name)
+        return name
+
+    def add_dep(self, function):
+        """ add a dependency """
+        if function not in self.filedep[1]:
+            self.filedep[0].add(function)
+
+    def get_deps(self):
+        """ get dependencies """
+        return self.filedep[0]
+
+    @staticmethod
+    def make_function_name(name):
+        """ Calculate OpenSCAD name from LDraw name. """
+        function_name = name.lower().split('.', 1)[0]
+        function_name = function_name.replace('\\', '__').replace('-', '_').\
+            replace(' ', '_')
+        return 'ldraw_lib__' + function_name + '()'
+
+    def convert_line_0(self, result, params, stripped):
+        """ Translate a '0' line. """
+        if len(params) >= 2 and params[1] == 'BFC':
+            for bfc in params[2:]:
+                result.append(f'  [0,"BFC","{bfc}"],')
+        if len(params) >= 2 and params[1] == 'STEP':
+            result.append('  [0,"STEP"],')
+        if len(params) >= 2 and params[1] == 'FILE':
+            intfile = stripped.split(maxsplit=2)[2]
+            if self.implement_function(intfile):
+                self.mpd_main = intfile
+            else:
+                result.append("];")
+                intfile_name = LDrawConverter.make_function_name(intfile)
+                result.append(f"function {intfile_name} = [")
+        if len(params) >= 2 and params[1] == 'NOFILE':
+            intfile = self.get_dummy()
+            result.append("];")
+            intfile_name = LDrawConverter.make_function_name(intfile)
+            result.append(f"function {intfile_name} = [")
+
+    def convert_line(self, part_line):
+        """ Translate a single line. """
+        stripped = part_line.rstrip()
+        result = [f"// {stripped}"] if self.settings['commented'] else []
+        params = stripped.split(maxsplit=14)
+        if not params:
+            return result
+        if params[0] == "0":
+            self.convert_line_0(result, params, stripped)
+        elif params[0] == "1":
+            self.add_dep(params[14])
+            result.append(
+                f"  [{','.join(params[:14])}, "
+                f"{LDrawConverter.make_function_name(params[14])}],")
+        elif params[0] in ["2", "3", "4", "5"]:
+            outparams = params[:{'2': 8, '3': 11, '4': 14, '5': 14}[params[0]]]
+            result.append(f"  [{','.join(outparams)}],")
+        return result
+
+    @staticmethod
+    def include(comp, path):
+        """ Generate use statement. """
+        relpath = (
+            os.path.join('openscad', *comp) if path == '/' else
+            os.path.relpath(os.path.join(*comp), path))
+        return f'use <{relpath}.scad>'
+
+    def process_lines(self, name, path, lines):
+        """ Translate all lines of a file. """
+        self.filedep = (set(), set())
+        self.mpd_main = None
+        result = []
+        for line in lines:
+            result.extend(self.convert_line(line))
+        function_name = LDrawConverter.make_function_name(name)
+        if self.settings['selfcontained']:
+            for file in self.get_deps():
+                self.enqueue(file, path)
+            result = [f"function {function_name} = ["] + result + ["];"]
+        else:
+            result = [LDrawConverter.include(['lib'], path)] + \
+                     [LDrawConverter.include(self.find_part(name), path)
+                      for name in sorted(self.get_deps())] + \
+                     [f"function {function_name} = ["] + result + ["];"] + \
+                     [f"makepoly({function_name}, "
+                      f"line={self.settings['line']});"]
+        if self.mpd_main and self.mpd_main != name:
+            main_function = LDrawConverter.make_function_name(self.mpd_main)
+            result.append(f"function {main_function} = {function_name};\n")
+        return result
+
+    def enqueue(self, name, path=None, ldrfile=None, scadfile=None):
+        """ enqueue a file to be processed """
+        if name not in self.queue[1]:
+            if not ldrfile:
+                lpath, base = self.find_part(name)
+            self.queue[0][name] = (
+                path if path else lpath,
+                (ldrfile if ldrfile else
+                 os.path.join(self.library_root, lpath, base) +
+                 ('.dat' if lpath != 'models' else '.ldr')),
+                (scadfile if scadfile else
+                 os.path.join('openscad', lpath, base) + '.scad'))
+
+    def process_queue(self):
+        """ process enqueued files """
+        while self.queue[0]:
+            name = sorted(self.queue[0].keys())[0]
+            path, ldrfile, scadfile = self.queue[0].pop(name)
+            self.queue[1].add(name)
+            with open(ldrfile, encoding="utf-8", errors='replace') as filedata:
+                lines = filedata.readlines()
+            result = '\n'.join(self.process_lines(name, path, lines))
+            if self.settings['selfcontained']:
+                self.settings['selfcontained'].write(result)
+            else:
+                scaddir = os.path.dirname(scadfile)
+                if scaddir:
+                    os.makedirs(os.path.dirname(scadfile), exist_ok=True)
+                with open(scadfile, 'w', encoding="utf-8") as fdw:
+                    fdw.write(result)
+
+    def convert_lib(self, selfcontained=False):
+        """ Convert the whole library """
+        for name in self.index:
+            self.enqueue(name)
+        if selfcontained:
+            with open('openscad.scad', 'w', encoding="utf-8") as fdw:
+                self.settings['selfcontained'] = fdw
+                fdw.write(self.colorfile())
+                with open('lib.scad', encoding="utf-8") as filedata:
+                    lines = filedata.readlines()
+                fdw.write(''.join(lines))
+                self.process_queue()
+        else:
+            os.makedirs('openscad', exist_ok=True)
+            with open('lib.scad', encoding="utf-8") as filedata:
+                lines = filedata.readlines()
+            with open(os.path.join('openscad', 'lib.scad'), 'w',
+                      encoding="utf-8") as fdw:
+                fdw.write('use <colors.scad>\n')
+                fdw.write(''.join(lines))
+            with open(os.path.join('openscad', 'colors.scad'), 'w',
+                      encoding="utf-8") as fdw:
+                fdw.write(self.colorfile())
+            self.process_queue()
+
+    def convert_file(self, ldrfile, scadfile, selfcontained=False):
+        """ Convert a single file """
+        self.enqueue('__main__', '/', ldrfile, scadfile)
+        if selfcontained:
+            with open(scadfile, 'w', encoding="utf-8") as fdw:
+                self.settings['selfcontained'] = fdw
+                fdw.write(self.colorfile())
+                with open('lib.scad', encoding="utf-8") as filedata:
+                    lines = filedata.readlines()
+                fdw.write(''.join(lines))
+                fdw.write('makepoly(ldraw_lib____main__(), '
+                          f"line={self.settings['line']});\n")
+                self.process_queue()
+        else:
+            self.process_queue()
+
 
 def main():
-    parser = argparse.ArgumentParser(description='Convert an LDraw part to OpenSCAD')
-    parser.add_argument('ldraw_file', metavar='FILENAME')
-    parser.add_argument('output_file', metavar='OUTPUT_FILENAME')
+    """ Main function """
+    parser = argparse.ArgumentParser(
+        description='Convert an LDraw part to OpenSCAD')
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument(
+        '-l', '--library', action='store_true',
+        help='translate the library')
+    parser.add_argument(
+        '-s', '--selfcontained', action='store_true',
+        help='create self-contained files')
+    parser.add_argument(
+        '-u', '--uncommented', action='store_true',
+        help='create uncommented files')
+    group.add_argument('ldraw_file', nargs='?', metavar='FILENAME',
+                       help='source file to translate')
+    parser.add_argument('output_file', nargs='?', metavar='OUTPUT_FILENAME',
+                        help='name of the translated file')
     parser.add_argument(
         '--line', default=0.2, type=float, metavar='LINE_WIDTH',
         help='width of lines, 0 for no lines')
     args = parser.parse_args()
-    convert = LDrawConverter()
-    with open(args.ldraw_file) as fd:
-        result = convert.process_main(fd, args.line)
-    with open(args.output_file, 'w') as fdw:
-        fdw.write('\n'.join(result))
+    converter = LDrawConverter(line=args.line, commented=not args.uncommented)
+    if args.library:
+        print("Translating library...")
+        converter.convert_lib(args.selfcontained)
+    else:
+        scadfile = args.output_file if args.output_file else \
+                   os.path.splitext(args.ldraw_file)[0] + '.scad'
+        print(f"Translating {args.ldraw_file} to {scadfile}...")
+        converter.convert_file(args.ldraw_file, scadfile, args.selfcontained)
 
 
 if __name__ == '__main__':

--- a/test_ldraw_to_scad.py
+++ b/test_ldraw_to_scad.py
@@ -2,30 +2,40 @@ from unittest import TestCase
 import mock
 import os
 
-from ldraw_to_scad import LDrawConverter, Module
+from ldraw_to_scad import LDrawConverter
 
 class TestModule(TestCase):
-    def default_runner(self, filename='a_module'):
-        return Module(filename=filename)
+    def default_runner(self):
+        return LDrawConverter()
 
-    def test_it_should_make_sensible_module_names(self):
+    def test_it_should_make_sensible_function_names(self):
         # Module names must be valid c identifiers - 
         # setup
-        module_names_to_convert = [
-            ["stud.dat", "n__stud"],
-            ["s\\stuff.dat", "n__s__stuff"],
-            ["4744.dat", "n__4744"],
-            ["2-4cyli.dat", "n__2_4cyli"]
+        function_names_to_convert = [
+            ["stud.dat", "ldraw_lib__stud()"],
+            ["s\\stuff.dat", "ldraw_lib__s__stuff()"],
+            ["4744.dat", "ldraw_lib__4744()"],
+            ["2-4cyli.dat", "ldraw_lib__2_4cyli()"]
         ]
         # test
         # assert
-        for item, expected in module_names_to_convert:
-            self.assertEqual(Module.make_module_name(item), expected)
+        for item, expected in function_names_to_convert:
+            self.assertEqual(LDrawConverter.make_function_name(item), expected)
+
+def listdir_mock(path):
+    return {
+        '.': ["simple_test.dat"],
+        'lib/ldraw/models': [],
+        'lib/ldraw/parts': ['1.dat'],
+        'lib/ldraw/p': ['4-4cyli.dat'],
+        'lib/ldraw/p/48': [],
+        'lib/ldraw/p/8': [],
+        'lib/ldraw/parts/s': ['4744s01.dat']
+    }[path]
 
 class TestFindPart(TestCase):
-    def default_runner(self, module_filename="__main__"):
-        module = Module(module_filename)
-        return LDrawConverter(), module
+    def default_runner(self):
+        return LDrawConverter()
 
 
     def test_it_should_be_able_to_find_part_path(self):
@@ -33,24 +43,13 @@ class TestFindPart(TestCase):
         # setup
         #  part tests - name, expected location
         part_tests = [
-            ['1.dat', os.path.join('lib', 'ldraw', 'parts', '1.dat')],
-            ['4-4cyli.dat', os.path.join('lib', 'ldraw', 'p', '4-4cyli.dat')],
-            ['s\\4744s01.dat', os.path.join('lib', 'ldraw', 'parts', 's', '4744s01.dat')]
+            ['1.dat', ('parts', '1')],
+            ['4-4cyli.dat', ('p', '4-4cyli')],
+            ['s\\4744s01.dat', (os.path.join('parts', 's'), '4744s01')]
         ]
-        def listdir_mock(path):
-            return {
-                '.': ["simple_test.dat"],
-                'lib/ldraw/parts': ['1.dat'],
-                'lib/ldraw/p': ['4-4cyli.dat'],
-                'lib/ldraw/p/48': [],
-                'lib/ldraw/p/8': [],
-                'lib/ldraw/parts/s': ['4744s01.dat']
-            }[path]
-
         with mock.patch("os.listdir", listdir_mock):
             # Test
-            converter, module = self.default_runner()
-            converter.index_library()
+            converter = self.default_runner()
 
         # Assert
         for part_name, expected_path in part_tests:
@@ -59,105 +58,92 @@ class TestFindPart(TestCase):
 
 def find_part_mock(_, part_name):
     """Dummy find part - just returns itself"""
-    return part_name
+    return ['.', os.path.splitext(part_name)[0]]
 
 
-def colorfile_mock(library_root):
+def colorfile_mock(_, library_root):
     """Dummy colorfile - just return empty file"""
     return ""
 
+@mock.patch("os.listdir", listdir_mock)
 @mock.patch("ldraw_to_scad.LDrawConverter.find_part", find_part_mock)
-@mock.patch("ldraw_to_scad.colorfile", colorfile_mock)
-# @mock.patch("ldraw_to_scad.LDrawConverter.get_module_lines", mock.Mock(return_value=[]))
+@mock.patch("ldraw_to_scad.LDrawConverter.colorfile", colorfile_mock)
+# @mock.patch("ldraw_to_scad.LDrawConverter.get_function_lines", mock.Mock(return_value=[]))
 class TestLDrawConverter(TestCase):
-    def default_runner(self, module_filename="__main__"):
-        module = Module(module_filename)
-        return LDrawConverter(), module
+    def default_runner(self, commented=True):
+        return LDrawConverter(commented=commented)
 
     def test_it_should_convert_comments(self):
         # setup
         part_lines_to_test =[
-            ["0 Stud", "// Stud"],
-            ["0", "// "]
+            ["0 Stud", "// 0 Stud"],
+            ["0", "// 0"]
         ]
-        converter, module = self.default_runner()
-        converter.current_module = module
+        converter = self.default_runner()
         # Test
         # Assert
         for line, expected in part_lines_to_test:
             output_scad = converter.convert_line(line)
             self.assertEqual(output_scad, [expected])
 
-    def test_it_should_convert_type_1_line_into_module_ref(self):
+    def test_it_should_convert_type_1_line_into_function_ref(self):
         # setup
         # This is a silly matrix - but the components are easy to pick out
         #      1 <colour> x  y  z  a  b  c  d  e  f  g  h  i <file>
         part_line = "1 16 25 24 23 22 21 20 19 18 17 16 15 14 simple_test.dat"
-        converter, module = self.default_runner()
+        converter = self.default_runner(commented=False)
+        converter.filedep = [set(), set()]
         # Test
-        converter.current_module = module
         result = converter.convert_line(part_line)
         # Assert
-        print(module.dependancies)
-        self.assertIn('n__simple_test', module.dependancies)
+        print(converter.filedep[0])
+        self.assertIn('simple_test.dat', converter.filedep[0])
         self.assertEqual(result, [
-            "[1, 16, 25, 24, 23, 22, 21, 20, 19, 18, 17, 16, 15, 14, n__simple_test()],"
+            "  [1,16,25,24,23,22,21,20,19,18,17,16,15,14, ldraw_lib__simple_test()],"
         ])
 
     def test_it_should_render_type_2_line(self):
         # setup
         part_line = "2 24 40 96 -20 -40 96 -20"
-        converter, module = self.default_runner()
+        converter = self.default_runner(commented=False)
         # test
-        converter.current_module = module
         output_scad = converter.convert_line(part_line)
         # assert
-        self.assertEqual(output_scad, ['[2, 24, 40, 96, -20, -40, 96, -20],'])
-        # With indent
-        output_scad = converter.convert_line(part_line, indent=2)
-        # assert
-        self.assertEqual(output_scad, ['  [2, 24, 40, 96, -20, -40, 96, -20],'])
+        self.assertEqual(output_scad, [
+            "  [2,24,40,96,-20,-40,96,-20],"
+        ])
 
     def test_it_should_render_type_3_tri(self):
         # setup
         part_line = "3 16 -2.017 -35.943 0 0 -35.942 -3.6 2.017 -35.943 0"
-        converter, module = self.default_runner()
+        converter = self.default_runner(commented=False)
         # test
-        converter.current_module = module
         output_scad = converter.convert_line(part_line)
         # assert
         self.assertEqual(output_scad, [
-            "[3, 16, -2.017, -35.943, 0, 0, -35.942, -3.6, 2.017, -35.943, 0],"
-        ])
-        # test with indent
-        output_scad = converter.convert_line(part_line, indent=2)
-        # assert
-        self.assertEqual(output_scad, [
-            "  [3, 16, -2.017, -35.943, 0, 0, -35.942, -3.6, 2.017, -35.943, 0],"
+            "  [3,16,-2.017,-35.943,0,0,-35.942,-3.6,2.017,-35.943,0],"
         ])
 
     def test_it_should_render_a_quad(self):
         # setup
         part_line = "4 16 1 1 0 0.9239 1 0.3827 0.9239 0 0.3827 1 0 0"
-        converter, module = self.default_runner()
+        converter = self.default_runner(commented=False)
         # Test
-        converter.current_module = module
         output_scad = converter.convert_line(part_line)
         # Assert
         self.assertEqual(output_scad, [
-            "[4, 16, 1, 1, 0, 0.9239, 1, 0.3827, 0.9239, 0, 0.3827, 1, 0, 0],"
+            "  [4,16,1,1,0,0.9239,1,0.3827,0.9239,0,0.3827,1,0,0],"
         ])
 
     def test_it_should_render_the_optional_line(self):
         # setup
         part_line = "5 24 0.7071 0 -0.7071 0.7071 1 -0.7071 0.9239 0 -0.3827 0.3827 0 -0.9239"
         # test
-        converter, module = self.default_runner()
-        converter.current_module = module
+        converter = self.default_runner(commented=False)
         output_scad = converter.convert_line(part_line)
         # assert
         self.assertEqual(output_scad, [
-            '[5, 24, 0.7071, 0, -0.7071, 0.7071, 1, -0.7071, 0.9239, 0, -0.3827, 0.3827, 0, -0.9239],'
+            '  [5,24,0.7071,0,-0.7071,0.7071,1,-0.7071,0.9239,0,-0.3827,0.3827,0,-0.9239],'
         ])
 
     def test_multiple_lines(self):
@@ -172,86 +158,89 @@ class TestLDrawConverter(TestCase):
             "4 16 0.7071 1 0.7071 0.3827 1 0.9239 0.3827 0 0.9239 0.7071 0 0.7071",
         ]
         # Test
-        converter, module = self.default_runner()
-        converter.process_lines(module, lines)
+        converter = self.default_runner()
+        result = converter.process_lines('__main__', '/', lines)
         # Assert
-        self.assertEqual(module.lines, [
-            "// Cylinder 1.0",
-            "// Name: 4-4cyli.dat",
-            "[4, 16, 1, 1, 0, 0.9239, 1, 0.3827, 0.9239, 0, 0.3827, 1, 0, 0],",
-            "[5, 24, 1, 0, 0, 1, 1, 0, 0.9239, 0, 0.3827, 0.9239, 0, -0.3827],",
-            "[4, 16, 0.9239, 1, 0.3827, 0.7071, 1, 0.7071, 0.7071, 0, 0.7071, 0.9239, 0, 0.3827],",
-            "[5, 24, 0.9239, 0, 0.3827, 0.9239, 1, 0.3827, 0.7071, 0, 0.7071, 1, 0, 0],",
-            "[4, 16, 0.7071, 1, 0.7071, 0.3827, 1, 0.9239, 0.3827, 0, 0.9239, 0.7071, 0, 0.7071],",
+        self.assertEqual(result, [
+            "use <openscad/lib.scad>",
+            "function ldraw_lib____main__() = [",
+            "// 0 Cylinder 1.0",
+            "// 0 Name: 4-4cyli.dat",
+            "// 4 16 1 1 0 0.9239 1 0.3827 0.9239 0 0.3827 1 0 0",
+            "  [4,16,1,1,0,0.9239,1,0.3827,0.9239,0,0.3827,1,0,0],",
+            "// 5 24 1 0 0 1 1 0 0.9239 0 0.3827 0.9239 0 -0.3827",
+            "  [5,24,1,0,0,1,1,0,0.9239,0,0.3827,0.9239,0,-0.3827],",
+            "// 4 16 0.9239 1 0.3827 0.7071 1 0.7071 0.7071 0 0.7071 0.9239 0 0.3827",
+            "  [4,16,0.9239,1,0.3827,0.7071,1,0.7071,0.7071,0,0.7071,0.9239,0,0.3827],",
+            "// 5 24 0.9239 0 0.3827 0.9239 1 0.3827 0.7071 0 0.7071 1 0 0",
+            "  [5,24,0.9239,0,0.3827,0.9239,1,0.3827,0.7071,0,0.7071,1,0,0],",
+            "// 4 16 0.7071 1 0.7071 0.3827 1 0.9239 0.3827 0 0.9239 0.7071 0 0.7071",
+            "  [4,16,0.7071,1,0.7071,0.3827,1,0.9239,0.3827,0,0.9239,0.7071,0,0.7071],",
+            "];",
+            "makepoly(ldraw_lib____main__(), line=0.2);"
         ])
 
     def test_reading_file(self):
         # Setup
         test_file = "simple_test.dat"
         # test
-        converter, _ = self.default_runner()
+        converter = self.default_runner()
         with open(test_file) as fd:
             lines = fd.readlines()
-        output = converter.process_main(lines)
+        output = converter.process_lines('__main__', '/', lines)
         # assert
-        self.assertEqual(output[1:], [
-            "function n____main__() = [",
-            "  // Simple Test File",
-            "  // Name: simple_test.dat",
+        self.assertEqual(output, [
+            "use <openscad/lib.scad>",
+            "function ldraw_lib____main__() = [",
+            "// 0 Simple Test File",
+            "// 0 Name: simple_test.dat",
+            "// 0 BFC CW",
             '  [0,"BFC","CW"],',
-            "  ",
-            "  [4, 16, 1, 1, 1, 1, 1, -1, -1, 1, -1, -1, 1, 1],",
-            "  ",
-            "];"
+            "// ",
+            "// 4 16  1 1  1  1 1 -1 -1 1 -1 -1 1  1",
+            "  [4,16,1,1,1,1,1,-1,-1,1,-1,-1,1,1],",
+            "// ",
+            "];",
+            "makepoly(ldraw_lib____main__(), line=0.2);"
         ])
     
-    def test_it_process_type_1_line_into_module(self):
+    def test_it_process_type_1_line_into_function(self):
         # setup
         part_lines = ["1 16 25 24 23 22 21 20 19 18 17 16 15 14 simple_test.dat"]
-        converter, _ = self.default_runner()
+        converter = self.default_runner(commented=False)
         # test
-        result = converter.process_main(part_lines)
+        result = converter.process_lines('__main__', '/', part_lines)
         # assert
         self.assertListEqual(
-            result[1:],
+            result,
             [
-                "function n__simple_test() = [",
-                "  // Simple Test File",
-                "  // Name: simple_test.dat",
-                '  [0,"BFC","CW"],',
-                "  ",
-                "  [4, 16, 1, 1, 1, 1, 1, -1, -1, 1, -1, -1, 1, 1],",
-                "  ",
+                "use <openscad/lib.scad>",
+                "use <openscad/./simple_test.scad>",
+                "function ldraw_lib____main__() = [",
+                "  [1,16,25,24,23,22,21,20,19,18,17,16,15,14, ldraw_lib__simple_test()],",
                 "];",
-                "function n____main__() = [",
-                "  [1, 16, 25, 24, 23, 22, 21, 20, 19, 18, 17, 16, 15, 14, n__simple_test()],",
-                "];"
+                "makepoly(ldraw_lib____main__(), line=0.2);"
             ]
         )
 
-    def test_multiple_lines_should_only_make_a_single_module_for_multiple_type_1_refs(self):
+    def test_multiple_lines_should_only_make_a_single_function_for_multiple_type_1_refs(self):
         # setup
         lines = [
             "1 16 25 24 23 22 21 20 19 18 17 16 15 14 simple_test.dat",
             "1 16 2.5 2.4 2.3 2.2 2.1 2.0 1.9 1.8 1.7 1.6 1.5 1.4 simple_test.dat",
         ]
         # Test
-        converter, _ = self.default_runner()
-        result = converter.process_main(lines)
+        converter = self.default_runner(commented=False)
+        result = converter.process_lines('__main__', '/', lines)
         # Assert
-        self.assertEqual(result[1:], [
-            "function n__simple_test() = [",
-            "  // Simple Test File",
-            "  // Name: simple_test.dat",
-            '  [0,"BFC","CW"],',
-            "  ",
-            "  [4, 16, 1, 1, 1, 1, 1, -1, -1, 1, -1, -1, 1, 1],",
-            "  ",
+        self.assertEqual(result, [
+            "use <openscad/lib.scad>",
+            "use <openscad/./simple_test.scad>",
+            "function ldraw_lib____main__() = [",
+            "  [1,16,25,24,23,22,21,20,19,18,17,16,15,14, ldraw_lib__simple_test()],",
+            "  [1,16,2.5,2.4,2.3,2.2,2.1,2.0,1.9,1.8,1.7,1.6,1.5,1.4, ldraw_lib__simple_test()],",
             "];",
-            "function n____main__() = [",
-            "  [1, 16, 25, 24, 23, 22, 21, 20, 19, 18, 17, 16, 15, 14, n__simple_test()],",
-            "  [1, 16, 2.5, 2.4, 2.3, 2.2, 2.1, 2.0, 1.9, 1.8, 1.7, 1.6, 1.5, 1.4, n__simple_test()],",
-            "];"
+            "makepoly(ldraw_lib____main__(), line=0.2);"
         ])
 
     def test_try_simplest_mpd(self):
@@ -267,53 +256,64 @@ class TestLDrawConverter(TestCase):
             "0 NOFILE"
         ]
         # test
-        converter, _ = self.default_runner()
-        result = converter.process_main(lines)
+        converter = self.default_runner(commented=False)
+        result = converter.process_lines('__main__', '/', lines)
         # assert
-        self.assertEqual(result[1:], [
-            "function n__mdr_inner() = [",
+        self.assertEqual(result, [
+            "use <openscad/lib.scad>",
+            "function ldraw_lib____main__() = [",
             '  [0,"BFC","CW"],',
-            "  [4, 16, 1, 1, 0, 0.9239, 1, 0.3827, 0.9239, 0, 0.3827, 1, 0, 0],",
-            "  ",
+            "  [1,16,225,224,223,222,221,220,219,218,217,216,215,214, ldraw_lib__mdr_inner()],",
             "];",
-            "function n____main__() = [",
+            "function ldraw_lib__dummy_1() = [",
+            "];",
+            "function ldraw_lib__mdr_inner() = [",
             '  [0,"BFC","CW"],',
-            "  [1, 16, 225, 224, 223, 222, 221, 220, 219, 218, 217, 216, 215, 214, n__mdr_inner()],",
-            "  ",
+            "  [4,16,1,1,0,0.9239,1,0.3827,0.9239,0,0.3827,1,0,0],",
             "];",
+            "function ldraw_lib__dummy_2() = [",
+            "];",
+            "makepoly(ldraw_lib____main__(), line=0.2);"
         ])
 
     def test_loading_an_mpd(self):
         # Setup
         mpd_filename = "mpd_test.dat"
         # Test
-        converter, _ = self.default_runner()
+        converter = self.default_runner()
         with open(mpd_filename) as fd:
-            output = converter.process_main(fd)
+            lines = fd.readlines()
+        output = converter.process_lines('__main__', '/', lines)
         # Assert
         self.maxDiff = None
-        self.assertListEqual(output[1:],
+        self.assertListEqual(output,
         [
-            "function n__simple_test() = [",
-            "  // Simple Test File",
-            "  // Name: simple_test.dat",
+            "use <openscad/lib.scad>",
+            "use <openscad/./simple_test.scad>",
+            "function ldraw_lib____main__() = [",
+            "// 0 FILE mdp_test.dat",
+            "// 0 Simple MPD File",
+            "// 0 Name: mdp_test.dat",
+            "// 0 BFC CW",
             '  [0,"BFC","CW"],',
-            "  ",
-            "  [4, 16, 1, 1, 1, 1, 1, -1, -1, 1, -1, -1, 1, 1],",
-            "  ",
+            "// ",
+            "// 1 16 225 224 223 222 221 220 219 218 217 216 215 214 mdr_inner.ldr",
+            "  [1,16,225,224,223,222,221,220,219,218,217,216,215,214, ldraw_lib__mdr_inner()],",
+            "// ",
+            "// 0 NOFILE",
             "];",
-            "function n__mdr_inner() = [",
+            "function ldraw_lib__dummy_1() = [",
+            "// 0 FILE mdr_inner.ldr",
+            "];",
+            "function ldraw_lib__mdr_inner() = [",
+            "// 0 BFC CW",
             '  [0,"BFC","CW"],',
-            "  [1, 16, 25, 24, 23, 22, 21, 20, 19, 18, 17, 16, 15, 14, n__simple_test()],",
-            "  ",
+            "// 1 16 25 24 23 22 21 20 19 18 17 16 15 14 simple_test.dat",
+            "  [1,16,25,24,23,22,21,20,19,18,17,16,15,14, ldraw_lib__simple_test()],",
+            "// 0 NOFILE",
             "];",
-            "function n____main__() = [",
-            "  // Simple MPD File",
-            "  // Name: mdp_test.dat",
-            '  [0,"BFC","CW"],',
-            "  ",
-            "  [1, 16, 225, 224, 223, 222, 221, 220, 219, 218, 217, 216, 215, 214, n__mdr_inner()],",
-            "  ",
-            "  ",
+            "function ldraw_lib__dummy_2() = [",
             "];",
+            "makepoly(ldraw_lib____main__(), line=0.2);",
+            "function ldraw_lib__mdp_test() = ldraw_lib____main__();\n"
         ])


### PR DESCRIPTION
This restructures the code to be more flexible and allows three modes of
operation:
1. Compile a single model file into a single self-contained OpenSCAD
   file. This is the old behavior.
2. Compile a single model file into an OpenSCAD file that relies on the
   presence of an LDraw OpenSCAD library. This is the new default.
3. Compile the whole LDraw library into an OpenSCAD library to support
   files translated in operation mode 2.

Technically there is also the option to translate the whole LDraw
library into a single library file. Due to the size of the LDraw
library, this has no practical use though since this causes OpenSCAD to
eat away all our memory when attempting to parse the result.

Additionally, this comes with the following features and benefits:
- Make the transfer of the original file contents as comments switchable
  with having them included being the default.
- New way of handling MPD files that seems more robust than the previous
  one. In particular, this can successfully translate the files from the
  model library on the LDraw site.