### PR TITLE
fix handling of MATERIAL tag in color specs

### DIFF
--- a/src/ldraw_to_scad/ldrawconverter.py
+++ b/src/ldraw_to_scad/ldrawconverter.py
@@ -224,6 +224,8 @@ class LDrawConverter:
     def enqueue(self, name, path=None, ldrfile=None, scadfile=None):
         """ enqueue a file to be processed """
         if name not in self.queue[1]:
+            lpath = None
+            base = None
             if not ldrfile:
                 lpath, base = self.find_part(name)
             self.queue[0][name] = (

--- a/src/ldraw_to_scad/ldrawconverter.py
+++ b/src/ldraw_to_scad/ldrawconverter.py
@@ -51,13 +51,15 @@ class LDrawConverter:
                             skip = False
                             continue
                         if opt in ['CODE', 'VALUE', 'ALPHA', 'LUMINANCE',
-                                   'EDGE', 'SIZE', 'MINSIZE', 'MAXSIZE',
-                                   'FRACTION', 'VFRACTION', 'MATERIAL']:
+                                   'EDGE']:
                             data[opt] = params[pos+4]
                             skip = True
                         elif opt in ['METAL', 'RUBBER', 'PEARLESCENT',
-                                     'CHROME']:
+                                     'CHROME', 'MATTE_METALLIC']:
                             data[opt] = True
+                        elif opt == 'MATERIAL':
+                            data[opt] = params[pos+1:]
+                            break
                         else:
                             print(f'Unknown !COLOUR option {opt}!')
                     alpha = int(data["ALPHA"]) if "ALPHA" in data else 255


### PR DESCRIPTION
When we face a MATERIAL tag all following tags is considered parameters to that tag and should not parsed further.